### PR TITLE
Correct "resilency" typo to "resiliency"

### DIFF
--- a/framework/devops_maturity_framework.md
+++ b/framework/devops_maturity_framework.md
@@ -24,7 +24,7 @@ Shift left on security | No security aspects considered during development cycle
 Build for resilience | No resilience build into system | Design infrastructure and code for failure | Design infrastructure and code for failure with fully automated error recovery (self-healing)
 Enable team for troubleshooting | No control over development lifecycle (e.g. access to PROD) | Team has full control over development lifecycle (e.g. access to PROD), but no access to logs and tools relevant for troubleshooting | Team has full control over development lifecycle (e.g. access to PROD) and full access to logs and tools for troubleshooting 
 Feature handling | No feature branches for controlled releases | Feature branches are implemented for controlled  releases of distinct features | Feature branching and toggles are implemented to facilitate development, roll-out and roll-back (if needed) of usable features to production
-Releases | Releases to all users and all sites / geographies in one go | Releases to subset of users or  sites or geographies | Gradual releases to subset of users in specific sites / geographies thereby limiting the blash raduis for potential issues
+Releases | Releases to all users and all sites / geographies in one go | Releases to subset of users or  sites or geographies | Gradual releases to subset of users in specific sites / geographies thereby limiting the blast raduis for potential issues
 
 #### PRODUCT & PROCESSES 
 

--- a/framework/devops_maturity_framework.md
+++ b/framework/devops_maturity_framework.md
@@ -38,7 +38,7 @@ Have a lightweight change approval process | Change approval needed from multipl
 Integrate application data into Big Data Platform | No application data transferred at all | Partial business-relevant application data transferred to Big Data Platform or provided via API | All business-relevant application data transferred to Big Data Platform
 SRE role and activities | No clear SRE role and responsibilty from Product team perspective | SRE tasks are defined and agreed from Execution (Operations, Automation, Hotfix) perspective | SRE tasks are defined for  Execution and Governance areas and agreed with all stakeholders (Business, Development)
 Postmortems | No causal analysis done for all outages | All outage RCA conducted and tied to change / release | Blameless Postmortems are conducted for all outages
-Resiliency / Chaos Engineering | No resiliency tests are conducted | Define environment dependencies (failure points) and execute resilency tests to ensure no customer impact | Regular chaos (resiliency) exercise scheduled basis stead state / functionality change
+Resiliency / Chaos Engineering | No resiliency tests are conducted | Define environment dependencies (failure points) and execute resiliency tests to ensure no customer impact | Regular chaos (resiliency) exercise scheduled basis stead state / functionality change
 
 #### MANAGEMENT & MONITORING 
 


### PR DESCRIPTION
Corrects a small typo of `resilency` to `resiliency`